### PR TITLE
837i

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+.DS_Store

--- a/misc/837i.xml
+++ b/misc/837i.xml
@@ -113,7 +113,7 @@
 
 				<Loop name="L2310A" max="1" required="y">
 					<Segment name="NM1" max="1"  required="n" comment="Attending Physician provider name"/>
-					<Segment name="PRV" max="1"  required="y" comment="Attending Physician specialty information"/>
+					<Segment name="PRV" max="1"  required="n" comment="Attending Physician specialty information"/>
 					<Segment name="REF" max="5"  required="n" comment="Attending Physician secondary id"/>
 				</Loop>
 				<Loop name="L2310B" max="1" required="n" comment="Operating Physician">
@@ -123,7 +123,7 @@
 				</Loop>
 				<Loop name="L2310C" required="n" comment="Other Operating Physician">
 					<Segment name="NM1" max="1"  required="n" comment="Other Operating Physician location"/>
-					<Segment name="PRV" max="1"  required="y" comment="Operating Physician specialty information"/>
+					<Segment name="PRV" max="1"  required="n" comment="Operating Physician specialty information"/>
 					<Segment name="REF" max="3"  required="n" comment="Other Operating Physician location secondary id"/>
 				</Loop>
 				<Loop name="L2310D" max="1" required="n" comment="Rendering Physician">

--- a/misc/837i.xml
+++ b/misc/837i.xml
@@ -2,8 +2,8 @@
    This file is part of the X12Parser library that provides tools to
    manipulate X12 messages using Ruby native syntax.
 
-   http://x12parser.rubyforge.org 
-   
+   http://x12parser.rubyforge.org
+
    Copyright (C) 2012 P&D Technical Solutions, LLC
 
    This library is free software; you can redistribute it and/or
@@ -20,13 +20,13 @@
    License along with this library; if not, write to the Free Software
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-   $Id: 837i.xml 2014-01-03 wylan using version 5010 $  
+   $Id: 837i.xml 2014-01-03 wylan using version 5010 $
 -->
 
 <Definition>
 	<Loop name="837i" required="y">
 		<Segment name="ISA" max="1" required="y" />
-		<Segment name="GS"  max="1" required="y" />	
+		<Segment name="GS"  max="1" required="y" />
 		<Loop name="L837" max="5000" comment="This X12 Transaction Set contains the format and establishes the data contents of the Institutional Healthcare Claim Transaction Set (837i) for use within the context of an Electronic Data Interchange (EDI) environment.">
 			<Segment name="ST"  max="1" required="y" />
 			<Segment name="BHT" max="1" required="y" />
@@ -34,7 +34,7 @@
 			<Loop name="L1000A" max="1" required="y">
 				<Segment name="NM1" max="1"  required="y" comment="Submitter EDI name"/>
 				<Segment name="PER" max="2"  required="y" comment="Submitter EDI contact information"/>
-			</Loop>	
+			</Loop>
 			<Loop name="L1000B" max="1" required="y">
 				<Segment name="NM1" max="1" required="y" comment="Receiver name"/>
 			</Loop>
@@ -66,20 +66,20 @@
 			<Loop name="L2000B" required="y">
 				<Segment name="HL"  max="1"  required="y" comment="Subscriber heiarchical level"/>
 				<Segment name="SBR" max="1"  required="y" comment="subscriber information"/>
-				
+
 				<Loop name="L2010BA" max="1" required="y">
 					<Segment name="NM1" max="1"  required="y" comment="Subscriber name"/>
 					<Segment name="N3"  max="1"  required="n" comment="Subscriber address"/>
 					<Segment name="N4"  max="1"  required="n" comment="Subscriber city/state/zip"/>
 					<Segment name="DMG" max="1"  required="n" comment="Subscriber demographic information"/>
-					<Segment name="REF" max="2"  required="n" comment="Subscriber Secondary Identification"/>			
+					<Segment name="REF" max="2"  required="n" comment="Subscriber Secondary Identification"/>
 					<Segment name="PER" max="1"  required="n" comment="Property and casualty subscriber contact information"/>
 				</Loop>
 				<Loop name="L2010BB" max="1" required="y">
 					<Segment name="NM1" max="1"  required="y" comment="Payer name"/>
 					<Segment name="N3"  max="1"  required="n" comment="Payer address"/>
 					<Segment name="N4"  max="1"  required="n" comment="Payer city/state/zip code"/>
-					<Segment name="REF" max="5"  required="n" />			
+					<Segment name="REF" max="5"  required="n" />
 				</Loop>
 			</Loop>
 			<Loop name="L2000C" required="n">
@@ -89,18 +89,18 @@
 					<Segment name="NM1" max="1"  required="y" comment="Patient name"/>
 					<Segment name="N3"  max="1"  required="y" comment="Patient address"/>
 					<Segment name="N4"  max="1"  required="y" comment="Patient city/state/zip"/>
-					<Segment name="DMG" max="1"  required="y" comment="Patient demographic information"/>		
+					<Segment name="DMG" max="1"  required="y" comment="Patient demographic information"/>
 					<Segment name="REF" max="1"  required="n" comment="Property and casualty claim number"/>
 				</Loop>
 			</Loop>
 			<Loop name="L2300" max="100" required="y">
 				<Segment name="CLM" max="1"  required="y" comment="Claim information"/>
 				<Segment name="DTP" max="4" required="n" comment="Claim Dates. Up to 4 different dates can be set for a 837i" />
-				<Segment name="CL1" max="1" required="n" comment="To supply information specific to hospital claims" />
+				<Segment name="CL1" max="1" required="Y" comment="To supply information specific to hospital claims" />
 				<Segment name="PWK" max="10" required="n" comment="Claim supplemental information" />
 				<Segment name="CN1" max="1"  required="n" comment="Contract information" />
 				<Segment name="AMT" max="1"  required="n" comment="PATIENT ESTIMATED AMOUNT DUE" />  <!-- AMT01 Amount Qualifier Code R AMT02 Patient Responsibility Amount R AMT03 Credit/Debit Flag Code N/U -->
-				<Segment name="REF" max="14" required="n" comment="Claim References.  Up to 14 different claim references can be set for a 837p" />			
+				<Segment name="REF" max="14" required="n" comment="Claim References.  Up to 14 different claim references can be set for a 837p" />
 				<Segment name="K3"  max="10" required="n" comment="File information" />
 				<Segment name="NTE" max="1"  required="n" comment="Claim note" />
 				<Segment name="CR1" max="1"  required="n" comment="Ambulance transport information" />
@@ -109,33 +109,32 @@
 				<Segment name="HI"  max="1"  required="y" comment="Healthcare diagnostic code" />
 				<Segment name="HI"  max="1"  required="n" comment="Anesthesia related procedure code" />
 				<Segment name="HI"  max="2"  required="n" comment="Condition information" />
-				<Segment name="HCP" max="1"  required="n" comment="Claim pricing / repricing information" />			
-					
-				<Loop name="L2310A" max="1" required="n">
-					<Segment name="NM1" max="1"  required="y" comment="Referring provider name"/>
-					<Segment name="REF" max="3"  required="n" comment="Referring provider secondary id"/>
+				<Segment name="HCP" max="1"  required="n" comment="Claim pricing / repricing information" />
+
+				<Loop name="L2310A" max="1" required="y">
+					<Segment name="NM1" max="1"  required="n" comment="Attending Physician provider name"/>
+					<Segment name="PRV" max="1"  required="y" comment="Attending Physician specialty information"/>
+					<Segment name="REF" max="5"  required="n" comment="Attending Physician secondary id"/>
 				</Loop>
 				<Loop name="L2310B" max="1" required="n" comment="Operating Physician">
 					<Segment name="NM1" max="1"  required="n" comment="Operating Physician name"/>
 					<Segment name="PRV" max="1"  required="n" comment="Operating Physician specialty information"/>
-					<Segment name="REF" max="4"  required="n" comment="Operating Physician secondary id"/>			
+					<Segment name="REF" max="4"  required="n" comment="Operating Physician secondary id"/>
 				</Loop>
 				<Loop name="L2310C" required="n" comment="Other Operating Physician">
-					<Segment name="NM1" max="1"  required="y" comment="Other Operating Physician location"/>
-					<Segment name="N3"  max="1"  required="y" comment="Other Operating Physician address"/>
-					<Segment name="N4"  max="1"  required="y" comment="Other Operating Physician city/state/zip"/>
-					<Segment name="REF" max="3"  required="n" comment="Other Operating Physician location secondary id"/>	
-					<Segment name="PER" max="1"  required="n" comment="Other Operating Physician contact information"/>
+					<Segment name="NM1" max="1"  required="n" comment="Other Operating Physician location"/>
+					<Segment name="PRV" max="1"  required="y" comment="Operating Physician specialty information"/>
+					<Segment name="REF" max="3"  required="n" comment="Other Operating Physician location secondary id"/>
 				</Loop>
 				<Loop name="L2310D" max="1" required="n" comment="Rendering Physician">
 					<Segment name="NM1" max="1"  required="n" comment="Rendering provider name"/>
-					<Segment name="REF" max="4"  required="n" comment="Rendering provider secondary id"/>			
+					<Segment name="REF" max="4"  required="n" comment="Rendering provider secondary id"/>
 				</Loop>
 				<Loop name="L2310E" max="1" required="n" comment="Service Facility Location">
 					<Segment name="NM1" max="1"  required="y" comment="Service Facility Location location"/>
 					<Segment name="N3"  max="1"  required="y" comment="Service Facility Location address"/>
 					<Segment name="N4"  max="1"  required="y" comment="Service Facility Location city/state/zip"/>
-					<Segment name="REF" max="3"  required="n" comment="Service facility location secondary id"/>	
+					<Segment name="REF" max="3"  required="n" comment="Service facility location secondary id"/>
 				</Loop>
 				<Loop name="L2310F" max="1" required="n" comment="Referring Provider">
 					<Segment name="NM1" max="1"  required="n" comment="Referring Provider location"/>
@@ -154,22 +153,22 @@
 					<Segment name="NM1" max="1"  required="y" comment="Other subscriber name"/>
 					<Segment name="N3"  max="1"  required="n" comment="Other subscriber address"/>
 					<Segment name="N4"  max="1"  required="y" comment="Other subscriber city/state/zip"/>
-					<Segment name="REF" max="2"  required="n" comment="Other subscriber location secondary id"/>	
+					<Segment name="REF" max="2"  required="n" comment="Other subscriber location secondary id"/>
 				</Loop>
 				<Loop name="L2330B" max="1" required="n">
 					<Segment name="NM1" max="1"  required="y" comment="Other payer name" />
 					<Segment name="N3"  max="1"  required="n" comment="Other payer address"/>
-					<Segment name="N4"  max="1"  required="y" comment="Other payer city/state/zip"/>		
+					<Segment name="N4"  max="1"  required="y" comment="Other payer city/state/zip"/>
 					<Segment name="DTP" max="1" required="n" comment="claim adjudiction date" />
-					<Segment name="REF" max="5"  required="n" comment="Other reference information. Up to 5 different references can be associated to an 837i" />	
-				</Loop>		
+					<Segment name="REF" max="5"  required="n" comment="Other reference information. Up to 5 different references can be associated to an 837i" />
+				</Loop>
 				<Loop name="L2330CDEFGH" max="6" required="n" comment="Loops 2330C through 2330H combined for inbound transactions, application needs to determine the correct loop being provided.">
 					<Segment name="NM1" max="1"  required="y" comment="Name" />
 					<Segment name="REF" max="3"  required="y" comment="Secondary id"/>
 				</Loop>
 				<Loop name="L23301" max="1" required="n" comment="Other Payer Billing Provider">
 					<Segment name="NM1" max="1"  required="n" comment="Other Payer Billing Provider"/>
-					<Segment name="REF" max="2"  required="n" comment="Other Payer Billing Provider ID"/>	
+					<Segment name="REF" max="2"  required="n" comment="Other Payer Billing Provider ID"/>
 				</Loop>
 				<Loop name="L2400" max="50" required="y">
 					<Segment name="LX"  max="1"  required="y" comment="Service line" />
@@ -203,15 +202,15 @@
 				</Loop>
 				<Loop name="L2420D" max="1" required="n" comment="Refering Provider">
 					<Segment name="NM1" max="1"  required="n" comment="Refering Provider provider name" />
-					<Segment name="REF" max="20" required="n" comment="Refering Provider provider secondary id" />			
+					<Segment name="REF" max="20" required="n" comment="Refering Provider provider secondary id" />
 				</Loop>
 				<Loop name="L2430" max="15" required="n">
 					<Segment name="SVD" max="1"  required="n" comment="Line adjudication information" />
 					<Segment name="CAS" max="5"  required="n" comment="Line adjustment" />
 					<Segment name="DTP" max="1"  required="y" comment="Line check or remittance date" />
-					<Segment name="AMT" max="1"  required="n" comment="Remaining patient liability" />		
-				</Loop>			
-			</Loop>			
+					<Segment name="AMT" max="1"  required="n" comment="Remaining patient liability" />
+				</Loop>
+			</Loop>
 			<Segment name="SE" required="y" />
 		</Loop>
 		<Segment name="GE"  max="1" required="y"/>

--- a/misc/837i.xml
+++ b/misc/837i.xml
@@ -1,0 +1,220 @@
+<!--
+   This file is part of the X12Parser library that provides tools to
+   manipulate X12 messages using Ruby native syntax.
+
+   http://x12parser.rubyforge.org 
+   
+   Copyright (C) 2012 P&D Technical Solutions, LLC
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+   $Id: 837i.xml 2014-01-03 wylan using version 5010 $  
+-->
+
+<Definition>
+	<Loop name="837i" required="y">
+		<Segment name="ISA" max="1" required="y" />
+		<Segment name="GS"  max="1" required="y" />	
+		<Loop name="L837" max="5000" comment="This X12 Transaction Set contains the format and establishes the data contents of the Institutional Healthcare Claim Transaction Set (837i) for use within the context of an Electronic Data Interchange (EDI) environment.">
+			<Segment name="ST"  max="1" required="y" />
+			<Segment name="BHT" max="1" required="y" />
+			<Segment name="REF" max="1"  required="n" comment="Transmission type identification"/>
+			<Loop name="L1000A" max="1" required="y">
+				<Segment name="NM1" max="1"  required="y" comment="Submitter EDI name"/>
+				<Segment name="PER" max="2"  required="y" comment="Submitter EDI contact information"/>
+			</Loop>	
+			<Loop name="L1000B" max="1" required="y">
+				<Segment name="NM1" max="1" required="y" comment="Receiver name"/>
+			</Loop>
+			<Loop name="L2000A" required="y">
+				<Segment name="HL"  max="1"  required="y" comment="Billing provider hierarchical level"/>
+				<Segment name="PRV" max="1"  required="n" comment="Billing provider specialty information"/>
+				<Segment name="CUR" max="1"  required="n" comment="Foreign currency information"/>
+				<Loop name="L2010AA" max="1" required="y">
+					<Segment name="NM1" max="1"  required="y" comment="Billing provider name"/>
+					<Segment name="N3"  max="1"  required="y" comment="Billing provider address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Billing provider city/state/zip code"/>
+					<Segment name="REF" max="1"  required="y" comment="Billing provider tax id"/>
+					<Segment name="REF" max="2"  required="n" comment="Billing provider upin/license information"/>
+					<Segment name="PER" max="2"  required="n" comment="Billing provider contact information"/>
+				</Loop>
+				<Loop name="L2010AB" max="1" required="n">
+					<Segment name="NM1" max="1"  required="n" comment="Pay-to address name"/>
+					<Segment name="N3"  max="1"  required="y" comment="Pay-to provider address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Pay-to provider city/state/zip code"/>
+				</Loop>
+				<Loop name="L2010AC" max="1" required="n">
+					<Segment name="NM1" max="1"  required="n" comment="Pay-to plan name"/>
+					<Segment name="N3"  max="1"  required="y" comment="Pay-to plan address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Pay-to plan city/state/zip code"/>
+					<Segment name="REF" max="1"  required="n" comment="Pay-to plan secondary id"/>
+					<Segment name="REF" max="1"  required="y" comment="Pay-to plan tax id"/>
+				</Loop>
+			</Loop>
+			<Loop name="L2000B" required="y">
+				<Segment name="HL"  max="1"  required="y" comment="Subscriber heiarchical level"/>
+				<Segment name="SBR" max="1"  required="y" comment="subscriber information"/>
+				
+				<Loop name="L2010BA" max="1" required="y">
+					<Segment name="NM1" max="1"  required="y" comment="Subscriber name"/>
+					<Segment name="N3"  max="1"  required="n" comment="Subscriber address"/>
+					<Segment name="N4"  max="1"  required="n" comment="Subscriber city/state/zip"/>
+					<Segment name="DMG" max="1"  required="n" comment="Subscriber demographic information"/>
+					<Segment name="REF" max="2"  required="n" comment="Subscriber Secondary Identification"/>			
+					<Segment name="PER" max="1"  required="n" comment="Property and casualty subscriber contact information"/>
+				</Loop>
+				<Loop name="L2010BB" max="1" required="y">
+					<Segment name="NM1" max="1"  required="y" comment="Payer name"/>
+					<Segment name="N3"  max="1"  required="n" comment="Payer address"/>
+					<Segment name="N4"  max="1"  required="n" comment="Payer city/state/zip code"/>
+					<Segment name="REF" max="5"  required="n" />			
+				</Loop>
+			</Loop>
+			<Loop name="L2000C" required="n">
+				<Segment name="HL"  required="y" comment="Patient heirarchical level"/>
+				<Segment name="PAT" required="y" comment="Patient information"/>
+				<Loop name="L2010CA" max="1" required="n">
+					<Segment name="NM1" max="1"  required="y" comment="Patient name"/>
+					<Segment name="N3"  max="1"  required="y" comment="Patient address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Patient city/state/zip"/>
+					<Segment name="DMG" max="1"  required="y" comment="Patient demographic information"/>		
+					<Segment name="REF" max="1"  required="n" comment="Property and casualty claim number"/>
+				</Loop>
+			</Loop>
+			<Loop name="L2300" max="100" required="y">
+				<Segment name="CLM" max="1"  required="y" comment="Claim information"/>
+				<Segment name="DTP" max="4" required="n" comment="Claim Dates. Up to 4 different dates can be set for a 837i" />
+				<Segment name="CL1" max="1" required="n" comment="To supply information specific to hospital claims" />
+				<Segment name="PWK" max="10" required="n" comment="Claim supplemental information" />
+				<Segment name="CN1" max="1"  required="n" comment="Contract information" />
+				<Segment name="AMT" max="1"  required="n" comment="PATIENT ESTIMATED AMOUNT DUE" />  <!-- AMT01 Amount Qualifier Code R AMT02 Patient Responsibility Amount R AMT03 Credit/Debit Flag Code N/U -->
+				<Segment name="REF" max="14" required="n" comment="Claim References.  Up to 14 different claim references can be set for a 837p" />			
+				<Segment name="K3"  max="10" required="n" comment="File information" />
+				<Segment name="NTE" max="1"  required="n" comment="Claim note" />
+				<Segment name="CR1" max="1"  required="n" comment="Ambulance transport information" />
+				<Segment name="CR2" max="1"  required="n" comment="Spinal manipulation service information" />
+				<Segment name="CRC" max="8"  required="n" comment="Code Category. Up to 8 different CRC categories can be set for an 837p" />
+				<Segment name="HI"  max="1"  required="y" comment="Healthcare diagnostic code" />
+				<Segment name="HI"  max="1"  required="n" comment="Anesthesia related procedure code" />
+				<Segment name="HI"  max="2"  required="n" comment="Condition information" />
+				<Segment name="HCP" max="1"  required="n" comment="Claim pricing / repricing information" />			
+					
+				<Loop name="L2310A" max="1" required="n">
+					<Segment name="NM1" max="1"  required="y" comment="Referring provider name"/>
+					<Segment name="REF" max="3"  required="n" comment="Referring provider secondary id"/>
+				</Loop>
+				<Loop name="L2310B" max="1" required="n" comment="Operating Physician">
+					<Segment name="NM1" max="1"  required="n" comment="Operating Physician name"/>
+					<Segment name="PRV" max="1"  required="n" comment="Operating Physician specialty information"/>
+					<Segment name="REF" max="4"  required="n" comment="Operating Physician secondary id"/>			
+				</Loop>
+				<Loop name="L2310C" required="n" comment="Other Operating Physician">
+					<Segment name="NM1" max="1"  required="y" comment="Other Operating Physician location"/>
+					<Segment name="N3"  max="1"  required="y" comment="Other Operating Physician address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Other Operating Physician city/state/zip"/>
+					<Segment name="REF" max="3"  required="n" comment="Other Operating Physician location secondary id"/>	
+					<Segment name="PER" max="1"  required="n" comment="Other Operating Physician contact information"/>
+				</Loop>
+				<Loop name="L2310D" max="1" required="n" comment="Rendering Physician">
+					<Segment name="NM1" max="1"  required="n" comment="Rendering provider name"/>
+					<Segment name="REF" max="4"  required="n" comment="Rendering provider secondary id"/>			
+				</Loop>
+				<Loop name="L2310E" max="1" required="n" comment="Service Facility Location">
+					<Segment name="NM1" max="1"  required="y" comment="Service Facility Location location"/>
+					<Segment name="N3"  max="1"  required="y" comment="Service Facility Location address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Service Facility Location city/state/zip"/>
+					<Segment name="REF" max="3"  required="n" comment="Service facility location secondary id"/>	
+				</Loop>
+				<Loop name="L2310F" max="1" required="n" comment="Referring Provider">
+					<Segment name="NM1" max="1"  required="n" comment="Referring Provider location"/>
+					<Segment name="N3"  max="1"  required="n" comment="Referring Provider address"/>
+					<Segment name="N4"  max="1"  required="n" comment="Referring Provider city/state/zip"/>
+				</Loop>
+				<Loop name="L2320" max="10" required="n">
+					<Segment name="SBR" max="1"  required="n" comment="Other subscriber information" />
+					<Segment name="CAS" max="5"  required="n" comment="Claim level adjustment" />
+					<Segment name="AMT" max="3"  required="n" comment="Claim level adjustment amounts" />
+					<Segment name="OI"  max="1"  required="y" comment="Other insurance coverage information" />
+					<Segment name="MIA" max="1"  required="n" comment="To provide claim-level data related to the adjudication of Medicare inpatient claims" />
+					<Segment name="MOA" max="1"  required="n" comment="Medicare outpatient adjudication information" />
+				</Loop>
+				<Loop name="L2330A" max="1" required="n">
+					<Segment name="NM1" max="1"  required="y" comment="Other subscriber name"/>
+					<Segment name="N3"  max="1"  required="n" comment="Other subscriber address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Other subscriber city/state/zip"/>
+					<Segment name="REF" max="2"  required="n" comment="Other subscriber location secondary id"/>	
+				</Loop>
+				<Loop name="L2330B" max="1" required="n">
+					<Segment name="NM1" max="1"  required="y" comment="Other payer name" />
+					<Segment name="N3"  max="1"  required="n" comment="Other payer address"/>
+					<Segment name="N4"  max="1"  required="y" comment="Other payer city/state/zip"/>		
+					<Segment name="DTP" max="1" required="n" comment="claim adjudiction date" />
+					<Segment name="REF" max="5"  required="n" comment="Other reference information. Up to 5 different references can be associated to an 837i" />	
+				</Loop>		
+				<Loop name="L2330CDEFGH" max="6" required="n" comment="Loops 2330C through 2330H combined for inbound transactions, application needs to determine the correct loop being provided.">
+					<Segment name="NM1" max="1"  required="y" comment="Name" />
+					<Segment name="REF" max="3"  required="y" comment="Secondary id"/>
+				</Loop>
+				<Loop name="L23301" max="1" required="n" comment="Other Payer Billing Provider">
+					<Segment name="NM1" max="1"  required="n" comment="Other Payer Billing Provider"/>
+					<Segment name="REF" max="2"  required="n" comment="Other Payer Billing Provider ID"/>	
+				</Loop>
+				<Loop name="L2400" max="50" required="y">
+					<Segment name="LX"  max="1"  required="y" comment="Service line" />
+					<Segment name="SV2" max="1"  required="y" comment="Institutional service" />
+					<Segment name="PWK" max="10" required="n" comment="Line supplemental informtion" />
+					<Segment name="DTP" max="1"  required="n" comment="Service Line Date" />
+					<Segment name="REF" max="3" required="n" />
+					<Segment name="AMT" max="2"  required="n" />
+					<Segment name="NTE" max="1"  required="n" comment="third party organization ntoes" />
+					<Segment name="HCP" max="1"  required="n" comment="Line pricing/repricing information" />
+				</Loop>
+				<Loop name="L2410" max="1" required="n" >
+					<Segment name="LIN" max="1"  required="n" comment="Drug identification" />
+					<Segment name="CTP" max="1"  required="y" comment="Drug Quantity" />
+					<Segment name="REF" max="1"  required="n" comment="Prescription or compound drug association number" />
+				</Loop>
+				<Loop name="L2420A" max="1" required="n" >
+					<Segment name="NM1" max="1"  required="n" comment="Rendering provider name" />
+					<Segment name="PRV" max="1"  required="n" comment="Rendering provider specialty information" />
+					<Segment name="REF" max="20" required="n" comment="Rendering provider secondary id" />
+				</Loop>
+				<Loop name="L2420B" max="1" required="n" >
+					<Segment name="NM1" max="1"  required="n" comment="Purchased service provider name" />
+					<Segment name="REF" max="20" required="n" comment="Purchased service provider secondary id" />
+				</Loop>
+				<Loop name="L2420C" max="1" required="n" comment="Rendering Provider">
+					<Segment name="NM1" max="1"  required="n" comment="Rendering Provider location name" />
+					<Segment name="N3"  max="1"  required="y" comment="Rendering Provider location address" />
+					<Segment name="N4"  max="1"  required="y" comment="Rendering Provider location city/state/zip" />
+					<Segment name="REF" max="3"  required="n" comment="Rendering Provider location secondary id" />
+				</Loop>
+				<Loop name="L2420D" max="1" required="n" comment="Refering Provider">
+					<Segment name="NM1" max="1"  required="n" comment="Refering Provider provider name" />
+					<Segment name="REF" max="20" required="n" comment="Refering Provider provider secondary id" />			
+				</Loop>
+				<Loop name="L2430" max="15" required="n">
+					<Segment name="SVD" max="1"  required="n" comment="Line adjudication information" />
+					<Segment name="CAS" max="5"  required="n" comment="Line adjustment" />
+					<Segment name="DTP" max="1"  required="y" comment="Line check or remittance date" />
+					<Segment name="AMT" max="1"  required="n" comment="Remaining patient liability" />		
+				</Loop>			
+			</Loop>			
+			<Segment name="SE" required="y" />
+		</Loop>
+		<Segment name="GE"  max="1" required="y"/>
+		<Segment name="IEA" max="1" required="y"/>
+	</Loop>
+</Definition>

--- a/misc/CAS.xml
+++ b/misc/CAS.xml
@@ -2,8 +2,8 @@
    This file is part of the X12Parser library that provides tools to
    manipulate X12 messages using Ruby native syntax.
 
-   http://x12parser.rubyforge.org 
-   
+   http://x12parser.rubyforge.org
+
    Copyright (C) 2009 APP Design, Inc.
 
    This library is free software; you can redistribute it and/or
@@ -27,20 +27,20 @@
   <Field name="ClaimAdjustmentGroupCode" min="1" max="2" validation="T1033" comment="Code identifying the general category of payment adjustment"/>
   <Field name="ClaimAdjustmentReasonCode1" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
   <Field name="MonetaryAmount1" type="double" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity1" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="ClaimAdjustmentReasonCode2" required="y" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
-  <Field name="MonetaryAmount2" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity2" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="ClaimAdjustmentReasonCode3" required="y" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
-  <Field name="MonetaryAmount3" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity3" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="ClaimAdjustmentReasonCode4" required="y" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
-  <Field name="MonetaryAmount4" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity4" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="ClaimAdjustmentReasonCode5" required="y" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
-  <Field name="MonetaryAmount5" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity5" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="ClaimAdjustmentReasonCode6" required="y" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
-  <Field name="MonetaryAmount6" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="Quantity6" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="Quantity1" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="ClaimAdjustmentReasonCode2" required="n" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
+  <Field name="MonetaryAmount2" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="Quantity2" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="ClaimAdjustmentReasonCode3" required="n" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
+  <Field name="MonetaryAmount3" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="Quantity3" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="ClaimAdjustmentReasonCode4" required="n" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
+  <Field name="MonetaryAmount4" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="Quantity4" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="ClaimAdjustmentReasonCode5" required="n" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
+  <Field name="MonetaryAmount5" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="Quantity5" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
+  <Field name="ClaimAdjustmentReasonCode6" required="n" min="1" max="5" comment="Code identifying the detailed reason the adjustment was made"/>
+  <Field name="MonetaryAmount6" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="Quantity6" type="double" required="n" min="1" max="15" comment="Numeric value of quantity"/>
 </Segment>

--- a/misc/CL1.xml
+++ b/misc/CL1.xml
@@ -25,7 +25,7 @@
 
 <Segment name="CL1" comment="To supply information specific to hospital claims">
   <Field name="AdmissionTypeCode" required="y" min="1" max="1" comment="Code indicating the priority of this admission"/>
-  <Field name="AdmissionSourceCode" required="y" min="1" max="1" comment="Code indicating the source of this admission"/>
-  <Field name="PatientStatusCode" required="y" min="1" max="2" comment="Code indicating patient status as of the &quot;statement covers through date&quot;"/>
-  <Field name="NursingHomeResidentialStatusCode" required="y" min="1" max="1" validation="T1345" comment="Code specifying the status of a nursing home resident at the time of service"/>
+  <Field name="AdmissionSourceCode" required="n" min="1" max="1" comment="Code indicating the source of this admission"/>
+  <Field name="PatientStatusCode" required="n" min="1" max="2" comment="Code indicating patient status as of the &quot;statement covers through date&quot;"/>
+  <Field name="NursingHomeResidentialStatusCode" required="n" min="1" max="1" validation="T1345" comment="Code specifying the status of a nursing home resident at the time of service"/>
 </Segment>

--- a/misc/CLM.xml
+++ b/misc/CLM.xml
@@ -29,7 +29,7 @@
   <Field name="ClaimFilingIndicatorCode" min="1" max="2" validation="T1032" comment="Code identifying type of claim"/>
   <Field name="NonInstitutionalClaimTypeCode" min="1" max="2" validation="T1343" comment="Code identifying the type of provider or claim"/>
   <Field name="HealthCareServiceLocationInformation" type="C023" required="y" min="0" max="inf" comment="To provide information that identifies the place of service or the type of bill related to the location at which a health care service was rendered"/>
-  <Field name="ProviderOrSupplierSignatureIndicator" required="y" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
+  <Field name="ProviderOrSupplierSignatureIndicator" required="n" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
   <Field name="MedicareAssignmentCode" required="y" min="1" max="1" validation="T1359" comment="Code indicating whether the provider accepts assignment"/>
   <Field name="BenefitsAssignmentCertificationIndicator" required="y" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
   <Field name="ReleaseOfInformationCode" required="y" min="1" max="1" validation="T1363" comment="Code indicating whether the provider has on file a signed statement by the patient authorizing the release of medical data to other organizations"/>

--- a/misc/HL.xml
+++ b/misc/HL.xml
@@ -25,7 +25,7 @@
 
 <Segment name="HL" comment="To identify dependencies among and the content of hierarchically related groups of data segments">
   <Field name="HierarchicalIdNumber" min="1" max="12" comment="A unique number assigned by the sender to identify a particular data segment in a hierarchical structure"/>
-  <Field name="HierarchicalParentIdNumber" required="y" min="1" max="12" comment="Identification number of the next higher hierarchical data segment that the data segment being described is subordinate to"/>
+  <Field name="HierarchicalParentIdNumber" required="n" min="1" max="12" comment="Identification number of the next higher hierarchical data segment that the data segment being described is subordinate to"/>
   <Field name="HierarchicalLevelCode" max="2" validation="T735" comment="Code defining the characteristic of a level in a hierarchical structure"/>
   <Field name="HierarchicalChildCode" required="y" min="1" max="1" validation="T736" comment="Code indicating if there are hierarchical child data segments subordinate to the level being described"/>
 </Segment>

--- a/misc/NM1.xml
+++ b/misc/NM1.xml
@@ -26,13 +26,13 @@
 <Segment name="NM1" comment="To supply the full name of an individual or organizational entity">
   <Field name="EntityIdentifierCode1"       required="y" min="2" max="3"  validation="T98"   comment="Code identifying an organizational entity, a physical location, property or an individual"/>
   <Field name="EntityTypeQualifier"         required="y" min="1" max="1"  validation="T1065" comment="Code qualifying the type of entity"/>
-  <Field name="NameLastOrOrganizationName"  required="y" min="1" max="60"                    comment="Individual last name or organizational name"/>
+  <Field name="NameLastOrOrganizationName"  required="n" min="1" max="60"                    comment="Individual last name or organizational name"/>
   <Field name="NameFirst"                   required="n" min="1" max="35"                    comment="Individual first name"/>
   <Field name="NameMiddle"                  required="n" min="1" max="25"                    comment="Individual middle name or initial"/>
   <Field name="NamePrefix"                  required="n" min="1" max="10"                    comment="Prefix to individual name"/>
   <Field name="NameSuffix"                  required="n" min="1" max="10"                    comment="Suffix to individual name"/>
-  <Field name="IdentificationCodeQualifier" required="y" min="1" max="2"  validation="T66"   comment="Code designating the system/method of code structure used for Identification Code (67)"/>
-  <Field name="IdentificationCode"          required="y" min="2" max="80"                    comment="Code identifying a party or other code"/>
+  <Field name="IdentificationCodeQualifier" required="n" min="1" max="2"  validation="T66"   comment="Code designating the system/method of code structure used for Identification Code (67)"/>
+  <Field name="IdentificationCode"          required="n" min="2" max="80"                    comment="Code identifying a party or other code"/>
   <Field name="EntityRelationshipCode"      required="n" min="2" max="2"  validation="T706"  comment="Code describing entity relationship"/>
   <Field name="EntityIdentifierCode"        required="n" min="2" max="3"  validation="T98"   comment="Code identifying an organizational entity, a physical location, property or an individual"/>
 </Segment>

--- a/misc/OI.xml
+++ b/misc/OI.xml
@@ -24,10 +24,10 @@
 -->
 
 <Segment name="OI" comment="To specify information associated with other health insurance coverage">
-  <Field name="ClaimFilingIndicatorCode" required="y" min="1" max="2" validation="T1032" comment="Code identifying type of claim"/>
-  <Field name="ClaimSubmissionReasonCode" required="y" min="2" max="2" validation="T1383" comment="Code identifying reason for claim submission"/>
+  <Field name="ClaimFilingIndicatorCode" required="n" min="1" max="2" validation="T1032" comment="Code identifying type of claim"/>
+  <Field name="ClaimSubmissionReasonCode" required="n" min="2" max="2" validation="T1383" comment="Code identifying reason for claim submission"/>
   <Field name="YesNoConditionOrResponseCode" required="y" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
-  <Field name="PatientSignatureSourceCode" required="y" min="1" max="1" validation="T1351" comment="Code indicating how the patient or subscriber authorization signatures were obtained and how they are being retained by the provider"/>
-  <Field name="ProviderAgreementCode" required="y" min="1" max="1" validation="T1360" comment="Code indicating the type of agreement under which the provider is submitting this claim"/>
+  <Field name="PatientSignatureSourceCode" required="n" min="1" max="1" validation="T1351" comment="Code indicating how the patient or subscriber authorization signatures were obtained and how they are being retained by the provider"/>
+  <Field name="ProviderAgreementCode" required="n" min="1" max="1" validation="T1360" comment="Code indicating the type of agreement under which the provider is submitting this claim"/>
   <Field name="ReleaseOfInformationCode" required="y" min="1" max="1" validation="T1363" comment="Code indicating whether the provider has on file a signed statement by the patient authorizing the release of medical data to other organizations"/>
 </Segment>

--- a/misc/PRV.xml
+++ b/misc/PRV.xml
@@ -27,7 +27,7 @@
   <Field name="ProviderCode" min="1" max="3" validation="T1221" comment="Code identifying the type of provider"/>
   <Field name="ReferenceIdentificationQualifier" required="y" min="2" max="3" validation="T128" comment="Code qualifying the Reference Identification"/>
   <Field name="ReferenceIdentification" required="y" min="1" max="50" comment="Reference information as defined for a particular Transaction Set or as specified by the Reference Identification Qualifier"/>
-  <Field name="StateOrProvinceCode" required="y" min="2" max="2" comment="Code (Standard State/Province) as defined by appropriate government agency"/>
-  <Field name="ProviderSpecialtyInformation" type="C035" required="y" min="0" max="inf" comment="To provide provider specialty information"/>
-  <Field name="ProviderOrganizationCode" required="y" min="3" max="3" validation="T1223" comment="Code identifying the organizational structure of a provider"/>
+  <Field name="StateOrProvinceCode" required="n" min="2" max="2" comment="Code (Standard State/Province) as defined by appropriate government agency"/>
+  <Field name="ProviderSpecialtyInformation" type="C035" required="n" min="0" max="inf" comment="To provide provider specialty information"/>
+  <Field name="ProviderOrganizationCode" required="n" min="3" max="3" validation="T1223" comment="Code identifying the organizational structure of a provider"/>
 </Segment>

--- a/misc/SV2.xml
+++ b/misc/SV2.xml
@@ -29,9 +29,9 @@
   <Field name="MonetaryAmount1" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
   <Field name="UnitOrBasisForMeasurementCode" required="y" min="2" max="2" validation="T355" comment="Code specifying the units in which a value is being expressed, or manner in which a measurement has been taken"/>
   <Field name="Quantity" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="UnitRate" type="double" required="y" min="1" max="10" comment="The rate per unit of associate revenue for hospital accommodation"/>
-  <Field name="MonetaryAmount2" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
-  <Field name="YesNoConditionOrResponseCode" required="y" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
-  <Field name="NursingHomeResidentialStatusCode" required="y" min="1" max="1" validation="T1345" comment="Code specifying the status of a nursing home resident at the time of service"/>
-  <Field name="LevelOfCareCode" required="y" min="1" max="1" validation="T1337" comment="Code specifying the level of care provided by a nursing home facility"/>
+  <Field name="UnitRate" type="double" required="n" min="1" max="10" comment="The rate per unit of associate revenue for hospital accommodation"/>
+  <Field name="MonetaryAmount2" type="double" required="n" min="1" max="18" comment="Monetary amount"/>
+  <Field name="YesNoConditionOrResponseCode" required="n" min="1" max="1" validation="T1073" comment="Code indicating a Yes or No condition or response"/>
+  <Field name="NursingHomeResidentialStatusCode" required="n" min="1" max="1" validation="T1345" comment="Code specifying the status of a nursing home resident at the time of service"/>
+  <Field name="LevelOfCareCode" required="n" min="1" max="1" validation="T1337" comment="Code specifying the level of care provided by a nursing home facility"/>
 </Segment>

--- a/misc/SV2.xml
+++ b/misc/SV2.xml
@@ -2,8 +2,8 @@
    This file is part of the X12Parser library that provides tools to
    manipulate X12 messages using Ruby native syntax.
 
-   http://x12parser.rubyforge.org 
-   
+   http://x12parser.rubyforge.org
+
    Copyright (C) 2009 APP Design, Inc.
 
    This library is free software; you can redistribute it and/or
@@ -25,7 +25,7 @@
 
 <Segment name="SV2" comment="To specify the claim service detail for a Health Care institution">
   <Field name="ProductServiceId" required="y" min="1" max="48" comment="Identifying number for a product or service"/>
-  <Field name="CompositeMedicalProcedureIdentifier" type="C003" required="y" min="0" max="inf" comment="To identify a medical procedure by its standardized codes and applicable modifiers"/>
+  <Field name="CompositeMedicalProcedureIdentifier" type="C003" required="n" min="0" max="inf" comment="To identify a medical procedure by its standardized codes and applicable modifiers"/>
   <Field name="MonetaryAmount1" type="double" required="y" min="1" max="18" comment="Monetary amount"/>
   <Field name="UnitOrBasisForMeasurementCode" required="y" min="2" max="2" validation="T355" comment="Code specifying the units in which a value is being expressed, or manner in which a measurement has been taken"/>
   <Field name="Quantity" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>

--- a/misc/SVD.xml
+++ b/misc/SVD.xml
@@ -2,8 +2,8 @@
    This file is part of the X12Parser library that provides tools to
    manipulate X12 messages using Ruby native syntax.
 
-   http://x12parser.rubyforge.org 
-   
+   http://x12parser.rubyforge.org
+
    Copyright (C) 2009 APP Design, Inc.
 
    This library is free software; you can redistribute it and/or
@@ -27,7 +27,7 @@
   <Field name="IdentificationCode" min="2" max="80" comment="Code identifying a party or other code"/>
   <Field name="MonetaryAmount" type="double" min="1" max="18" comment="Monetary amount"/>
   <Field name="CompositeMedicalProcedureIdentifier" type="C003" required="y" min="0" max="inf" comment="To identify a medical procedure by its standardized codes and applicable modifiers"/>
-  <Field name="ProductServiceId" required="y" min="1" max="48" comment="Identifying number for a product or service"/>
+  <Field name="ProductServiceId" required="n" min="1" max="48" comment="Identifying number for a product or service"/>
   <Field name="Quantity" type="double" required="y" min="1" max="15" comment="Numeric value of quantity"/>
-  <Field name="AssignedNumber" type="long" required="y" min="1" max="6" comment="Number assigned for differentiation within a transaction set"/>
+  <Field name="AssignedNumber" type="long" required="n" min="1" max="6" comment="Number assigned for differentiation within a transaction set"/>
 </Segment>


### PR DESCRIPTION
I've been meaning to make a pull request for this for a while. I added a 837i.xml file, based on the the 837p file with some changes and additional segments as needed.

I also had to make some changes to the required field on several segments. If they are marked as required=y and have a minimum character count, blank spaces are generated in the field when creating a message. This caused the resulting 837i to be rejected by some receivers as invalid. 

This hasn't caused any issues for the other message types we use (837p, 835, 277, 999). 

Hopefully someone finds this useful, please let me know if any changes are needed.
